### PR TITLE
disable "delete_selected" admin action only for DjangoBB models

### DIFF
--- a/djangobb_forum/admin.py
+++ b/djangobb_forum/admin.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
+
 from django.contrib import admin
 from django.contrib.auth import admin as auth_admin
 from django.contrib.auth.models import User
@@ -8,14 +9,23 @@ from djangobb_forum.models import Category, Forum, Topic, Post, Profile, Reputat
     Report, Ban, Attachment
 
 
-class CategoryAdmin(admin.ModelAdmin):
+class BaseModelAdmin(admin.ModelAdmin):
+    def get_actions(self, request):
+        # disabled, because delete_selected ignoring delete model method
+        actions = super(BaseModelAdmin, self).get_actions(request)
+        if 'delete_selected' in actions:
+            del actions['delete_selected']
+        return actions
+
+
+class CategoryAdmin(BaseModelAdmin):
     list_display = ['name', 'position', 'forum_count']
 
-class ForumAdmin(admin.ModelAdmin):
+class ForumAdmin(BaseModelAdmin):
     list_display = ['name', 'category', 'position', 'topic_count']
     raw_id_fields = ['moderators', 'last_post']
 
-class TopicAdmin(admin.ModelAdmin):
+class TopicAdmin(BaseModelAdmin):
     def subscribers2(self, obj):
         return ", ".join([user.username for user in obj.subscribers.all()])
     subscribers2.short_description = _("subscribers")
@@ -24,37 +34,37 @@ class TopicAdmin(admin.ModelAdmin):
     search_fields = ['name']
     raw_id_fields = ['user', 'subscribers', 'last_post']
 
-class PostAdmin(admin.ModelAdmin):
+class PostAdmin(BaseModelAdmin):
     list_display = ['topic', 'user', 'created', 'updated', 'summary']
     search_fields = ['body']
     raw_id_fields = ['topic', 'user', 'updated_by']
 
-class ProfileAdmin(admin.ModelAdmin):
+class ProfileAdmin(BaseModelAdmin):
     list_display = ['user', 'status', 'time_zone', 'location', 'language']
     raw_id_fields = ['user']
 
-class ReputationAdmin(admin.ModelAdmin):
+class ReputationAdmin(BaseModelAdmin):
     list_display = ['from_user', 'to_user', 'post', 'sign', 'time', 'reason']
     raw_id_fields = ['from_user', 'to_user', 'post']
 
-class ReportAdmin(admin.ModelAdmin):
+class ReportAdmin(BaseModelAdmin):
     list_display = ['reported_by', 'post', 'zapped', 'zapped_by', 'created', 'reason']
     raw_id_fields = ['reported_by', 'post']
 
-class BanAdmin(admin.ModelAdmin):
+class BanAdmin(BaseModelAdmin):
     list_display = ['user', 'ban_start', 'ban_end', 'reason']
     raw_id_fields = ['user']
 
 class UserAdmin(auth_admin.UserAdmin):
     list_display = ['username', 'email', 'first_name', 'last_name', 'is_staff', 'is_active']
-    
+
     def get_urls(self):
         from django.conf.urls.defaults import patterns, url
         return patterns('',
                         url(r'^(\d+)/password/$', self.admin_site.admin_view(self.user_change_password), name='user_change_password'),
                         ) + super(auth_admin.UserAdmin, self).get_urls()
 
-class AttachmentAdmin(admin.ModelAdmin):
+class AttachmentAdmin(BaseModelAdmin):
     list_display = ['id', 'name', 'size', 'path', 'hash', ]
     search_fields = ['name']
     list_display_links = ('name',)
@@ -74,4 +84,3 @@ admin.site.register(Report, ReportAdmin)
 admin.site.register(Ban, BanAdmin)
 admin.site.register(Attachment, AttachmentAdmin)
 
-admin.site.disable_action('delete_selected')  #disabled, because delete_selected ignoring delete model method


### PR DESCRIPTION
disable "delete_selected" admin action only for DjangoBB models and not globaly.

`admin.site.disable_action('delete_selected')` would disable the action for all models.
