### PR TITLE
Bugfix in JS: Reset onbeforeunload event while edit a existing post, too...

### DIFF
--- a/djangobb_forum/static/djangobb_forum/js/markup/bbcode/board.js
+++ b/djangobb_forum/static/djangobb_forum/js/markup/bbcode/board.js
@@ -89,7 +89,7 @@ $(document).ready(function() {
         }
         // if nothing returned, browser leave the page without any message
     };
-    $("form#post").bind("submit", function() {
+    $("form input[type=submit]").click(function() {
         //log("unbind onbeforeunload");
         window.onbeforeunload = null;
     });


### PR DESCRIPTION
before the patch: You will get the "leave page" JS message while editing a post.
The "unbind" only work if a new post created and not while editing.
