### PR TITLE
Got traceback on topic view if the user has spaces in it.

### DIFF
--- a/djangobb_forum/templates/djangobb_forum/topic.html
+++ b/djangobb_forum/templates/djangobb_forum/topic.html
@@ -106,7 +106,7 @@
 						{% endif %}
 						{% if forum_settings.PM_SUPPORT %}
 							{% if user.is_authenticated %}
-								<a href="{% url messages_compose_to post.user.username %}">{% trans "PM" %}</a>&nbsp;&nbsp;</dd>
+								<a href="{% url messages_compose_to "post.user.username" %}">{% trans "PM" %}</a>&nbsp;&nbsp;</dd>
 							{% endif %}
 						{% endif %}
 				</dl>


### PR DESCRIPTION
Fixes tracebacks if username contains spaces
