### PR TITLE
Fixed 'UnicodeDecodeError' while opennig an attachment file with UTF-8 name

### DIFF
--- a/djangobb_forum/views.py
+++ b/djangobb_forum/views.py
@@ -826,7 +826,7 @@ def show_attachment(request, hash):
     attachment = get_object_or_404(Attachment, hash=hash)
     file_data = file(attachment.get_absolute_path(), 'rb').read()
     response = HttpResponse(file_data, mimetype=attachment.content_type)
-    response['Content-Disposition'] = 'attachment; filename="%s"' % smart_str(attachment.name)
+    response['Content-Disposition'] = smart_str('attachment; filename="%s"' % attachment.name)
     return response
 
 


### PR DESCRIPTION
Details here: http://djangobb.org/ticket/252