### PR TITLE
Update to Django1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.py[co]
 *.egg-info
+*.egg
 .pydevproject
 .project
 .settings

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.py[co]
 *.egg-info
 *.egg
+.idea/
 .pydevproject
 .project
 .settings
@@ -12,3 +13,5 @@ local_settings.py
 .env
 build/
 dist/
+.tox/
+venv/

--- a/djangobb_forum/models.py
+++ b/djangobb_forum/models.py
@@ -290,7 +290,7 @@ class Reputation(models.Model):
 class ProfileManager(models.Manager):
     use_for_related_fields = True
     def get_queryset(self):
-        qs = super(self).get_queryset()
+        qs = super(ProfileManager, self).get_queryset()
         if forum_settings.REPUTATION_SUPPORT:
             qs = qs.extra(select={
                 'reply_total': 'SELECT SUM(sign) FROM djangobb_forum_reputation WHERE to_user_id = djangobb_forum_profile.user_id GROUP BY to_user_id',

--- a/djangobb_forum/models.py
+++ b/djangobb_forum/models.py
@@ -289,8 +289,8 @@ class Reputation(models.Model):
 
 class ProfileManager(models.Manager):
     use_for_related_fields = True
-    def get_query_set(self):
-        qs = super(ProfileManager, self).get_query_set()
+    def get_queryset(self):
+        qs = super(self).get_queryset()
         if forum_settings.REPUTATION_SUPPORT:
             qs = qs.extra(select={
                 'reply_total': 'SELECT SUM(sign) FROM djangobb_forum_reputation WHERE to_user_id = djangobb_forum_profile.user_id GROUP BY to_user_id',

--- a/djangobb_forum/templates/djangobb_forum/profile/profile_essentials.html
+++ b/djangobb_forum/templates/djangobb_forum/profile/profile_essentials.html
@@ -25,7 +25,7 @@
 							{% if user.is_superuser %}
 								<a href="{% url 'admin:user_change_password' profile.id %}">{% trans "Change password" %}</a>
 							{% else %}
-								<a href="{% url 'auth_password_change' %}">{% trans "Change password" %}</a>
+								<a href="{% url 'account_change_password' %}">{% trans "Change password" %}</a>
 							{% endif %}
 							</p>
 					</div>

--- a/djangobb_forum/tests/test_utils.py
+++ b/djangobb_forum/tests/test_utils.py
@@ -32,6 +32,7 @@ class TestParsers(TestCase):
         bb_data = convert_text_to_html(self.bbcode, 'bbcode')
         self.assertEqual(bb_data, "<strong>Lorem</strong> <div class=\"code\"><pre>ipsum :)</pre></div><a href=\"http://djangobb.org/\" rel=\"nofollow\">http://djangobb.org/</a> =)")
 
+
 class TestPaginators(TestCase):
     fixtures = ['test_forum.json']
 
@@ -56,4 +57,4 @@ class TestVersion(TestCase):
         djangobb_forum.version_info = (0, 2, 1, 'f', 0)
         self.assertEqual(djangobb_forum.get_version(), '0.2.1')
         djangobb_forum.version_info = (2, 3, 1, 'a', 5)
-        self.assertIn('2.3.1a5.dev', djangobb_forum.get_version())
+        self.assertIn(djangobb_forum.get_version(), '2.3.1a5.dev')

--- a/djangobb_forum/views.py
+++ b/djangobb_forum/views.py
@@ -77,7 +77,7 @@ def index(request, full=True):
         return render(request, 'djangobb_forum/lofi/index.html', to_return)
 
 
-@transaction.commit_on_success
+@transaction.atomic
 def moderate(request, forum_id):
     forum = get_object_or_404(Forum, pk=forum_id)
     topics = forum.topics.order_by('-sticky', '-updated').select_related()
@@ -360,7 +360,7 @@ def show_forum(request, forum_id, full=True):
         return render(request, 'djangobb_forum/lofi/forum.html', to_return)
 
 
-@transaction.commit_on_success
+@transaction.atomic
 def show_topic(request, topic_id, full=True):
     """
     * Display a topic
@@ -472,7 +472,7 @@ def show_topic(request, topic_id, full=True):
 
 
 @login_required
-@transaction.commit_on_success
+@transaction.atomic
 def add_topic(request, forum_id):
     """
     create a new topic, with or without poll
@@ -528,7 +528,7 @@ def add_topic(request, forum_id):
     return render(request, 'djangobb_forum/add_topic.html', context)
 
 
-@transaction.commit_on_success
+@transaction.atomic
 def upload_avatar(request, username, template=None, form_class=None):
     user = get_object_or_404(User, username=username)
     if request.user.is_authenticated() and user == request.user or request.user.is_superuser:
@@ -551,7 +551,7 @@ def upload_avatar(request, username, template=None, form_class=None):
                })
 
 
-@transaction.commit_on_success
+@transaction.atomic
 def user(request, username, section='essentials', action=None, template='djangobb_forum/profile/profile_essentials.html', form_class=EssentialsProfileForm):
     user = get_object_or_404(User, username=username)
     if request.user.is_authenticated() and user == request.user or request.user.is_superuser:
@@ -577,7 +577,7 @@ def user(request, username, section='essentials', action=None, template='djangob
 
 
 @login_required
-@transaction.commit_on_success
+@transaction.atomic
 def reputation(request, username):
     user = get_object_or_404(User, username=username)
     form = build_form(ReputationForm, request, from_user=request.user, to_user=user)
@@ -629,7 +629,7 @@ def show_post(request, post_id):
 
 
 @login_required
-@transaction.commit_on_success
+@transaction.atomic
 def edit_post(request, post_id):
     from djangobb_forum.templatetags.forum_extras import forum_editable_by
 
@@ -652,7 +652,7 @@ def edit_post(request, post_id):
 
 
 @login_required
-@transaction.commit_on_success
+@transaction.atomic
 def delete_posts(request, topic_id):
 
     topic = Topic.objects.select_related().get(pk=topic_id)
@@ -697,7 +697,7 @@ def delete_posts(request, topic_id):
 
 
 @login_required
-@transaction.commit_on_success
+@transaction.atomic
 def move_topic(request):
     if 'topic_id' in request.GET:
         #if move only 1 topic
@@ -736,7 +736,7 @@ def move_topic(request):
 
 
 @login_required
-@transaction.commit_on_success
+@transaction.atomic
 def stick_unstick_topic(request, topic_id, action):
     topic = get_object_or_404(Topic, pk=topic_id)
     if forum_moderated_by(topic, request.user):
@@ -751,7 +751,7 @@ def stick_unstick_topic(request, topic_id, action):
 
 
 @login_required
-@transaction.commit_on_success
+@transaction.atomic
 def delete_post(request, post_id):
     post = get_object_or_404(Post, pk=post_id)
     last_post = post.topic.last_post
@@ -777,7 +777,7 @@ def delete_post(request, post_id):
 
 
 @login_required
-@transaction.commit_on_success
+@transaction.atomic
 def open_close_topic(request, topic_id, action):
     topic = get_object_or_404(Topic, pk=topic_id)
     if forum_moderated_by(topic, request.user):
@@ -801,7 +801,7 @@ def users(request):
 
 
 @login_required
-@transaction.commit_on_success
+@transaction.atomic
 def delete_subscription(request, topic_id):
     topic = get_object_or_404(Topic, pk=topic_id)
     topic.subscribers.remove(request.user)
@@ -813,7 +813,7 @@ def delete_subscription(request, topic_id):
 
 
 @login_required
-@transaction.commit_on_success
+@transaction.atomic
 def add_subscription(request, topic_id):
     topic = get_object_or_404(Topic, pk=topic_id)
     topic.subscribers.add(request.user)

--- a/extras/optional-requirements.txt
+++ b/extras/optional-requirements.txt
@@ -1,2 +1,5 @@
--e git://github.com/jtauber/django-mailer.git#egg=django-mailer
-https://github.com/arneb/django-messages/tarball/master#egg=django-messages
+django-allauth
+django-messages
+
+# for django < 1.7, you'll want south
+# south

--- a/extras/requirements.txt
+++ b/extras/requirements.txt
@@ -1,10 +1,9 @@
-Django>=1.6,<1.7
-Pillow>=2.1.0
+Django>=1.6
 django-haystack>=2.1.0,<2.4
-south
-pygments
+Pillow>=2.1.0
 postmarkup
+pygments
+pytz>=2013b
 # As soon as a release after v2.0.2 is made, we can revert to a normal PyPI requirement
 # Python 3 support is brand new in this package
 -e git://github.com/zyga/django-pagination.git#egg=linaro-django-pagination
-pytz>=2013b

--- a/setup.py
+++ b/setup.py
@@ -19,17 +19,19 @@ class compile_translations(Command):
         import os
         import sys
         import django
-        from django.core.management.commands.compilemessages import \
-            compile_messages
+        from django.core.management.commands import compilemessages
         from django.core.management.base import CommandError
 
         curdir = os.getcwd()
         os.chdir(os.path.realpath('djangobb_forum'))
         try:
-            if django.VERSION[:2] >= (1, 6):
-                compile_messages(stdout=sys.stdout)
+            if django.VERSION[:2] >= (1, 7):
+                command_object = compilemessages.Command()
+                command_object.compile_messages(stdout=sys.stdout)
+            elif django.VERSION[:2] == (1, 6):
+                compilemessages.compile_messages(stdout=sys.stdout)
             else:
-                compile_messages(stderr=sys.stderr)
+                compilemessages.compile_messages(stderr=sys.stderr)
         except CommandError:
             # raised if gettext pkg not installed
             pass

--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,10 @@ setup(name='djangobb_forum',
     include_package_data=True,
     setup_requires=['django>=1.6,<1.7'],
     install_requires=[
-            'django>=1.6,<1.7',
+            'django>=1.6',
             'pillow>=2.1.0',
             'django-haystack>=2.1.0,<2.4',
             'linaro-django-pagination',
-            'south',
             'postmarkup',
             'setuptools',
             'pytz>=2013b'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-1.5, py27-1.6, py34-1.6
+envlist = py27-1.5, py27-1.6, py27-1.7, py34-1.6, py34-1.7
 
 [testenv]
 downloadcache = {toxworkdir}/_download/
@@ -8,18 +8,27 @@ commands =
 setenv =
     PYTHONPATH = {toxinidir}
 
-
 [testenv:py27-1.5]
 basepython = python2.7
 deps =
-Django==1.5.7
+    Django==1.5.7
 
 [testenv:py27-1.6]
 basepython = python2.7
 deps =
     Django==1.6.4
 
+[testenv:py27-1.7]
+basepython = python2.7
+deps =
+    Django==1.7.1
+
 [testenv:py34-1.6]
 basepython = python3.4
 deps =
-    Django == 1.6.4
+    Django==1.6.4
+
+[testenv:py34-1.7]
+basepython = python3.4
+deps =
+    Django==1.7.1


### PR DESCRIPTION
This gets rid of all the warnings that come from using DjangoBB with Django >= 1.7

I've expanded the tox tests to include Django 1.7.1 and it is all green.

There are a few other things:
* fixed broken test that failed on iteration of tox
* updated requirements as most package are now available on pypi
* updated .gitignore