### PR TITLE
Add missing migration

### DIFF
--- a/djangobb_forum/migrations/0002_auto_20150524_1558.py
+++ b/djangobb_forum/migrations/0002_auto_20150524_1558.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangobb_forum', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='category',
+            name='groups',
+            field=models.ManyToManyField(blank=True, verbose_name='Groups', help_text='Only users from these groups can see this category', to='auth.Group'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='forum',
+            name='moderators',
+            field=models.ManyToManyField(blank=True, verbose_name='Moderators', to=settings.AUTH_USER_MODEL),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='poll',
+            name='users',
+            field=models.ManyToManyField(blank=True, help_text='Users who has voted this poll.', to=settings.AUTH_USER_MODEL),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
Model change in 75814ac1bba7517c20683f6ec06a98c2bc431b04 required a
migration to be added, which was not done.

This commit corrects the situation.

The new django migrations are nice because they constantly nag you that you have a missing `makemigrations` when you use the project, so you can't go for very long without doing them :)