### PR TITLE
Support Python 3.5.

### DIFF
--- a/djangobb_forum/util.py
+++ b/djangobb_forum/util.py
@@ -3,7 +3,13 @@
 import re
 from django.utils.six.moves import html_parser
 HTMLParser = html_parser.HTMLParser
-HTMLParseError = html_parser.HTMLParseError
+try:
+    HTMLParseError = html_parser.HTMLParseError
+except AttributeError:
+    # create a dummy class for Python 3.5+ where it's been removed
+    class HTMLParseError(Exception):
+        pass
+
 from postmarkup import render_bbcode
 from json import JSONEncoder
 try:


### PR DESCRIPTION
Currently DjangoBB fails to run in Python 3.5 as Python 3.5 has removed the deprecated HTMLParserError. This PR proposes to fix the issue by introducing a dummy HTMLParserError class.

Note that Django has fixed the issue. The issue has been raised in https://code.djangoproject.com/ticket/23763. The fix in Django is at https://github.com/django/django/commit/b07aa52e8a8e4c7fdc7265f75ce2e7992e657ae9