### PR TITLE
Fix bug causing forum index to be empty for some users

### DIFF
--- a/djangobb_forum/fields.py
+++ b/djangobb_forum/fields.py
@@ -96,7 +96,8 @@ class JSONField(models.TextField):
             if isinstance(value, six.string_types):
                 return json.loads(value)
         except ValueError:
-            raise ValidationError(_("Invalid JSON"))
+            pass
+        return None
 
     def get_prep_value(self, value):
         if value == "":


### PR DESCRIPTION
When `PostTracking.topics` would contain invalid JSON (such as `{'42':
12}` which contains single quoted keys), the user linked to this
tracking would always see an empty forum index.

The reason for this is because `JSONField` would raise `ValidationError`
on de-serialization errors, which would cause the templating engines
(which calls `forum_unreads()` from `forum_extras`) to fail silently and
simply not output anything (thus not showing forums).

I couldn't figure why we raised this `ValidationError` there in the
first place, so I removed it and returned `None` instead.