### PR TITLE
Allow jQuery URL override

### DIFF
--- a/djangobb_forum/settings.py
+++ b/djangobb_forum/settings.py
@@ -31,6 +31,7 @@ USER_TO_USER_EMAIL = get('DJANGOBB_USER_TO_USER_EMAIL', True)
 POST_USER_SEARCH = get('DJANGOBB_POST_USER_SEARCH', 1)
 NOTIFICATION_HANDLER = get('DJANGOBB_NOTIFICATION_HANDLER', 'djangobb_forum.subscription.email_topic_subscribers')
 ENABLE_POLLS = get('DJANGOBB_ENABLE_POLLS', True)
+JQUERY_URL = get('DJANGOBB_JQUERY_URL', '//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.0/jquery.min.js')
 
 # GRAVATAR Extension
 GRAVATAR_SUPPORT = get('DJANGOBB_GRAVATAR_SUPPORT', True)

--- a/djangobb_forum/templates/djangobb_forum/base.html
+++ b/djangobb_forum/templates/djangobb_forum/base.html
@@ -19,11 +19,7 @@
 		var STATIC_URL = "{{ STATIC_URL }}";
 		var POST_PREVIEW_URL = "{% url 'djangobb:post_preview' %}";
 	</script>
-	{% if DEBUG %}
-	   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.0/jquery.js"></script>
-	{% else %}
-    	<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.0/jquery.min.js" ></script>
-	{% endif %}
+    <script type="text/javascript" src="{{ forum_settings.JQUERY_URL }}" ></script>
 	{% if user.is_authenticated %}
     	{% if post %}
             {% with markup=post.markup %}


### PR DESCRIPTION
Allow jQuery's URL (currently a hardcoded URL to a cloudflare CDN) to be
overridden by the forum project.

I did this because I was intermittently getting SSL warnings because of
mixed contents. I felt that self-hosting was the easiest way to solve
this problem, so I added this setting.

As far as I can tell, this is the only hardcoded outside reference we
have, so it should be the only case where we need such an override.