### PR TITLE
Update README.md with Django>=1.8 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ DjangoBB consists of 2 parts:
 
 #### Compatibility
   * Python **2.7/3.3+**
-  * Django >= **1.7**
+  * Django >= **1.8**
 
 Fore more info pls check ''requirements.txt'' and ''optional-requirements.txt'' files
 


### PR DESCRIPTION
Django 1.7 is no longer supported since commit
2a23984aee0ddfd958274b8cd0dd56007bd6f0ce ("better django 1.9 support;
drop django support < 1.8").