### PR TITLE
Fixed models.Report.reason max_length attribute

### DIFF
--- a/djangobb_forum/models.py
+++ b/djangobb_forum/models.py
@@ -357,7 +357,7 @@ class Report(models.Model):
     zapped = models.BooleanField(_('Zapped'), blank=True, default=False)
     zapped_by = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='zapped_by', blank=True, null=True, verbose_name=_('Zapped by'))
     created = models.DateTimeField(_('Created'), blank=True)
-    reason = models.TextField(_('Reason'), blank=True, default='', max_length='1000')
+    reason = models.TextField(_('Reason'), blank=True, default='', max_length=1000)
 
     class Meta:
         verbose_name = _('Report')


### PR DESCRIPTION
Although its value is ignored by database code, it is probably used by the form validation code; still, it should be an integer.